### PR TITLE
Return UNKNOWN type for multi-line log containing []

### DIFF
--- a/LogAnalyzer/LogAnalyzer.java
+++ b/LogAnalyzer/LogAnalyzer.java
@@ -1587,86 +1587,89 @@ public class LogAnalyzer
          int bracket2Start = s.indexOf("[", bracket1End + 1);
          int bracket2End = s.indexOf("]", bracket1End + 1);
 
-         if (multidb)
-         {
-            bracket2Start = s.indexOf("[", bracket2End + 1);
-            bracket2End = s.indexOf("]", bracket2End + 1);
-         }
+         if (bracket2Start != -1) {
+            if (multidb) {
+               bracket2Start = s.indexOf("[", bracket2End + 1);
+               bracket2End = s.indexOf("]", bracket2End + 1);
+            }
 
-         String type = s.substring(bracket2End + 2, s.indexOf(":", bracket2End + 2));
+            String type = s.substring(bracket2End + 2, s.indexOf(":", bracket2End + 2));
 
-         if ("LOG".equals(type))
-         {
-            return LOG;
+            if ("LOG".equals(type))
+            {
+               return LOG;
+            }
+            else if ("STATEMENT".equals(type))
+            {
+               return STATEMENT;
+            }
+            else if ("DETAIL".equals(type))
+            {
+               return DETAIL;
+            }
+            else if ("NOTICE".equals(type))
+            {
+               return NOTICE;
+            }
+            else if ("PANIC".equals(type))
+            {
+               return PANIC;
+            }
+            else if ("FATAL".equals(type))
+            {
+               return FATAL;
+            }
+            else if ("ERROR".equals(type))
+            {
+               return ERROR;
+            }
+            else if ("WARNING".equals(type))
+            {
+               return WARNING;
+            }
+            else if ("INFO".equals(type))
+            {
+               return INFO;
+            }
+            else if ("DEBUG".equals(type))
+            {
+               return DEBUG1;
+            }
+            else if ("DEBUG1".equals(type))
+            {
+               return DEBUG1;
+            }
+            else if ("DEBUG2".equals(type))
+            {
+               return DEBUG2;
+            }
+            else if ("DEBUG3".equals(type))
+            {
+               return DEBUG3;
+            }
+            else if ("DEBUG4".equals(type))
+            {
+               return DEBUG4;
+            }
+            else if ("DEBUG5".equals(type))
+            {
+               return DEBUG5;
+            }
+            else if ("HINT".equals(type))
+            {
+               return HINT;
+            }
+            else if ("CONTEXT".equals(type))
+            {
+               return CONTEXT;
+            }
+            else {
+               System.out.println("Unknown log line type for: " + s);
+               System.exit(1);
+            }
          }
-         else if ("STATEMENT".equals(type))
-         {
-            return STATEMENT;
-         }
-         else if ("DETAIL".equals(type))
-         {
-            return DETAIL;
-         }
-         else if ("NOTICE".equals(type))
-         {
-            return NOTICE;
-         }
-         else if ("PANIC".equals(type))
-         {
-            return PANIC;
-         }
-         else if ("FATAL".equals(type))
-         {
-            return FATAL;
-         }
-         else if ("ERROR".equals(type))
-         {
-            return ERROR;
-         }
-         else if ("WARNING".equals(type))
-         {
-            return WARNING;
-         }
-         else if ("INFO".equals(type))
-         {
-            return INFO;
-         }
-         else if ("DEBUG".equals(type))
-         {
-            return DEBUG1;
-         }
-         else if ("DEBUG1".equals(type))
-         {
-            return DEBUG1;
-         }
-         else if ("DEBUG2".equals(type))
-         {
-            return DEBUG2;
-         }
-         else if ("DEBUG3".equals(type))
-         {
-            return DEBUG3;
-         }
-         else if ("DEBUG4".equals(type))
-         {
-            return DEBUG4;
-         }
-         else if ("DEBUG5".equals(type))
-         {
-            return DEBUG5;
-         }
-         else if ("HINT".equals(type))
-         {
-            return HINT;
-         }
-         else if ("CONTEXT".equals(type))
-         {
-            return CONTEXT;
-         }
-         else
-         {
-            System.out.println("Unknown log line type for: " + s);
-            System.exit(1);
+         else {
+            return UNKNOWN;
          }
       }
 


### PR DESCRIPTION
e.g. Following log line fails

4288 [2019-10-24 05:05:11.736 EDT] [0] LOG:  duration: 2.042 ms  statement: SELECT c.relname, ns.nspname FROM pg_catalog.pg_class c
	 JOIN pg_catalog.pg_namespace ns ON c.relnamespace OPERATOR(pg_catalog.=) ns.oid
	 LEFT JOIN pg_catalog.pg_class t ON c.reltoastrelid OPERATOR(pg_catalog.=) t.oid
	 WHERE c.relkind OPERATOR(pg_catalog.=) ANY (array['r', 'm'])
	 ORDER BY c.relpages DESC;


at ```array['r', 'm']```